### PR TITLE
Different URLs should not have the same link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,8 @@ A remark-lint plugin that warns against non-descriptive link text.
 
 The linter warns against:
 
-- click here
-- here
-- read more
-- this link
-- more here
-- this article
-- this [whatever words in between] article
-
-And [several others](src/banned.ts).
+- contextless phrases such as "click here" and "read more."
+- link text that's used more than once for different URLs.
 
 💡 For all banned phrases that begin with `this` or `the`, any words that come between will also fail. For example "this post", "this Mapbox post", and "this Mapbox blog post" will all fail.
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -71,6 +71,18 @@ describe("remark-lint-link-text", () => {
     expect(lint.messages.length).toEqual(0);
   });
 
+  test("unique link text", async () => {
+    const lint = await processMarkdown(
+      dedent`Visit the [staff directory](https://www.directory.org) to learn more. You can visit the other [staff directory](https://www.other-directory.org) to learn other stuff.`
+    );
+    expect(lint.messages).toMatchInlineSnapshot(`
+      Array [
+        [1:11-1:55: The link text "staff directory" is used more than once with different URLs. Change the link text to be unique to the URL.],
+        [1:95-1:145: The link text "staff directory" is used more than once with different URLs. Change the link text to be unique to the URL.],
+      ]
+    `);
+  });
+
   test("warns against banned link text, regex match", async () => {
     const lint = await processMarkdown(
       dedent`

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,8 @@ function checkBannedWords(file: VFile, nodes: TextNode[], text: string) {
 }
 
 function checkUniqueLinkText(file: VFile, nodes: TextNode[], text: string) {
-  const urls = [...new Set(nodes.map((node) => node.url))];
-  if (urls.length > 1) {
+  const uniqueUrls = [...new Set(nodes.map(({ url }) => url))];
+  if (uniqueUrls.length > 1) {
     for (const node of nodes) {
       file.message(
         `The link text "${text}" is used more than once with different URLs. Change the link text to be unique to the URL.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,13 @@ const checkLinkText = lintRule(
     for (const txt of Object.keys(textToNodes)) {
       const nodes = textToNodes[txt];
       if (!nodes) return;
-
       // test regex
       checkRegexBannedWords(file, nodes, txt);
 
       // test banned words
       checkBannedWords(file, nodes, txt);
+
+      checkUniqueLinkText(file, nodes, txt);
     }
   }
 );
@@ -56,6 +57,18 @@ function checkBannedWords(file: VFile, nodes: TextNode[], text: string) {
   if (banned.includes(text.toLowerCase())) {
     for (const node of nodes) {
       createMessage(file, node, text);
+    }
+  }
+}
+
+function checkUniqueLinkText(file: VFile, nodes: TextNode[], text: string) {
+  const urls = [...new Set(nodes.map((node) => node.url))];
+  if (urls.length > 1) {
+    for (const node of nodes) {
+      file.message(
+        `The link text "${text}" is used more than once with different URLs. Change the link text to be unique to the URL.`,
+        node
+      );
     }
   }
 }


### PR DESCRIPTION
This PR adds a new check that will warn/error if there's more than one link with the same link text, but the URL destinations are different.