### PR TITLE
Avoid URLs as the link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ The linter warns against:
 - more here
 - this article
 - this [whatever words in between] article
-
-And [several others](src/banned.ts).
+- using a URL as the link text.
 
 💡 For all banned phrases that begin with `this` or `the`, any words that come between will also fail. For example "this post", "this Mapbox post", and "this Mapbox blog post" will all fail.
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -48,6 +48,17 @@ describe("remark-lint-link-text", () => {
     );
   });
 
+  test("warns against url as link text", async () => {
+    const lint = await processMarkdown(
+      dedent`A bad link: [https://github.com.com](https://github.com.com).`
+    );
+
+    expect(lint.messages.length).toEqual(1);
+    expect(lint.messages[0].reason).toMatchInlineSnapshot(
+      `"Avoid using a URL as the link text “https://github.com.com”. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination."`
+    );
+  });
+
   test("the...documentation should pass", async () => {
     const lint = await processMarkdown(
       dedent`

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -60,7 +60,7 @@ describe("remark-lint-link-text", () => {
 
     expect(lint.messages.length).toEqual(1);
     expect(lint.messages[0].reason).toMatchInlineSnapshot(
-      `"Avoid using a URL as the link text “https://github.com.com”. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination."`
+      `"Avoid using a URL “https://github.com.com” as the link text. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination."`
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ function checkIsNotUrl(file: VFile, nodes: TextNode[], text: string) {
   ) {
     for (const node of nodes) {
       file.message(
-        `Avoid using a URL as the link text “${text}”. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination.`,
+        `Avoid using a URL “${text}” as the link text. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination.`,
         node
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const checkLinkText = lintRule(
 
       // test banned words
       checkBannedWords(file, nodes, txt);
+
+      checkIsNotUrl(file, nodes, txt);
     }
   }
 );
@@ -56,6 +58,21 @@ function checkBannedWords(file: VFile, nodes: TextNode[], text: string) {
   if (banned.includes(text.toLowerCase())) {
     for (const node of nodes) {
       createMessage(file, node, text);
+    }
+  }
+}
+
+function checkIsNotUrl(file: VFile, nodes: TextNode[], text: string) {
+  if (
+    text.match(
+      /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/
+    )
+  ) {
+    for (const node of nodes) {
+      file.message(
+        `Avoid using a URL as the link text “${text}”. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination.`,
+        node
+      );
     }
   }
 }


### PR DESCRIPTION
This PR will add another check that warns against using URLs as the link text