### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,15 @@
 # remark-lint-link-text
 
-A remark-lint plugin that warns against non-descriptive link text.
+A [remark-lint](https://github.com/remarkjs/remark-lint) plugin that warns against non-descriptive link text.
 
 ```md
-✅ Visit [Mapbox documentation](https://docs.mapbox.com) to learn more.
-🚫 Learn more [here](https://docs.mapbox.com).
+✅ Check out [W3C’s Web Accessibility Initiative](https://www.w3.org/WAI) to learn more.
+🚫 Learn more [here](https://www.w3.org/WAI).
 ```
 
-The linter warns against:
+## Installation and usage
 
-- contextless phrases such as "click here" and "read more."
-- link text that's used more than once for different URLs.
-- using a URL as the link text.
-- missing link text or missing alt text if the link is an image.
-
-💡 For all banned phrases that begin with `this` or `the`, any words that come between will also fail. For example "this post", "this Mapbox post", and "this Mapbox blog post" will all fail.
-
-## Install
-
-```
+```shell
 npm install --save-dev remark-cli @double-great/remark-lint-link-text
 ```
 
@@ -32,21 +23,99 @@ Add the plugin to your remark configuration:
 },
 ```
 
-## Banned link text
+## List of warnings
 
-Save banned link text in [src/banned.ts](src/banned.ts).
+### Link text is not descriptive
 
-## Proper link text guidelines
+Pulling from [this library’s list of bad link text](src/banned.ts), any link text that matches this list will be flagged. Using non-specific link text is a [failure of WCAG 2.4.9 (AAA)](https://www.w3.org/WAI/WCAG21/Techniques/failures/F84.html).
 
-> When calling the user to action, use brief but meaningful link text that:
->
-> - provides some information when read out of context
-> - explains what the link offers
-> - doesn't talk about mechanics
-> - is not a verb phrase
+Here’s a sample of the phrases in [`src/banned.ts`](src/banned.ts):
 
-- https://www.w3.org/QA/Tips/noClickHere
+- click here
+- read more
+- learn more
+- website
+- found here
+- this article
 
-> Write links that make sense out of context. Use descriptive link text detailing the destination; not just “click here,” or other similar phrases.
+💡 For all banned phrases that begin with `this` or `the`, any words that come between will also fail. For example "this post", "this W3C post", and "this W3C blog post" will all fail.
 
-- http://accessibility.psu.edu/linktext/
+### Link text is not unique
+
+This warning relates to [WCAG 2.4.9 Link Purpose (Link Only) (AAA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=249#link-purpose-link-only) and [WCAG 3.2.4 Consistent Navigation (AA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=324#consistent-identification). Links with different purposes and destinations should have different link text. Descriptive link text communicates a link's purpose even when the context is missing. A screen reader listing all of the links on a page is an example where the context would be missing.
+
+🚫 The following markdown will cause a warning:
+```md
+- [Example](https://example.com/team)
+- [Example](https://example.com/about)
+```
+
+✅ The following markdown will *not* cause a warning:
+```md
+- [Example team](https://example.com/team)
+- [About Example](https://example.com/about)
+```
+
+💡 This check does not account for techniques that use `aria-label` or `aria-labelledby` attributes to provide additional link context. Context provided by content that surrounds the link, as allowed by [WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context), is not considered by this check.
+
+### Link text is a URL
+
+[WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context) considers a link containing text that gives a description of the information at that URL a sufficient technique. When a URL is the link text, screen readers have to listen while the reader pronounces every single character of a URL. Audibly, this is less descriptive and more time consuming to listen to than descriptive link text. [WebAIM's Links and Hypertext page](https://webaim.org/techniques/hypertext/link_text) explains the challenges of [URLs as links](https://webaim.org/techniques/hypertext/link_text#urls).
+
+🚫 The following markdown will cause a warning:
+```md
+[https://www.w3c.org/WAI/fundamentals/accessibility-intro/](https://www.w3c.org/WAI/fundamentals/accessibility-intro/)
+```
+
+When read aloud, users will hear "h t t p s colon slash slash w w w dot w 3 c dot org slash w a i slash fundementals slash accessibility dash intro slash, link".
+
+✅ The following markdown will *not* cause a warning:
+```md
+[Introduction to Web Accessibility](https://www.w3c.org/WAI/fundamentals/accessibility-intro/)
+```
+
+When read aloud, users will hear "Introduction to Web Accessibility, link".
+
+💡 This check is at odds with some stylistic guidelines, like APA. The [APA Style’s Accessible URLs page](https://apastyle.apa.org/style-grammar-guidelines/paper-format/accessibility/urls) provides some rationale for their guidelines as it relates to [WCAG 2.4.4](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context).
+
+### Link text is missing
+
+In markdown, missing link text is often an oversight. Although an [`<a>` element without a `href` attribute is valid](https://html.spec.whatwg.org/#the-a-element) HTML, [WebAIM suggests that empty links can be very confusing](https://webaim.org/techniques/hypertext/link_text#empty_links) to keyboard and screen reader users and should be avoided completely.
+
+🚫 The following markdown will cause a warning:
+```md
+[](https://example.com)
+```
+
+✅ The following markdown will *not* cause a warning:
+```md
+[Example](https://example.com)
+```
+
+### Linked image is missing alt text
+
+When an image is the only content in a link, alt text is required. In this context, missing alt text is a [failure of WCAG 2.4.4 (A), 2.4.9 (AAA), and 4.1.2 (A)](https://www.w3.org/WAI/WCAG21/Techniques/failures/F89).
+
+🚫 The following markdown will cause a warning:
+```md
+[![](https://example.com/logo.svg)](https://example.com)
+```
+
+✅ The following markdown will *not* cause a warning:
+```md
+[![Example logo](https://example.com/logo.svg)](https://example.com)
+```
+
+💡 When an image is the only content in a link, the image's alt text effectively becomes the link text. Based on [WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context), the alt text should describle the function of the link (instead of describing the image).
+
+## More link text resources
+
+- [A11y Collective: The Perfect Link](https://www.a11y-collective.com/blog/the-perfect-link/)
+- [Get Stark: The endless search for "here" in the unhelpful "click here" button](https://www.getstark.co/blog/the-endless-search-for-here-in-the-unhelpful-click-here-button)
+- [NC State University: Accessible Hyperlinks](https://accessibility.oit.ncsu.edu/accessible-hyperlinks/)
+- [Penn State: Link Text](https://accessibility.psu.edu/linktext/)
+- [WCAG 2.4.4: Link Purpose](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)
+- [WCAG 2.4.9: Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only.html)
+- [WCAG 3.2.4: Consistent Identification](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html)
+- [WCAG 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+- [WebAIM: Links and Hypertext - Link Text and Appearance](https://webaim.org/techniques/hypertext/link_text)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Here’s a sample of the phrases in [`src/banned.ts`](src/banned.ts):
 - found here
 - this article
 
+🚫 The following markdown will cause a warning:
+
+```md
+- [click here](https://example.com/team)
+```
+
+✅ The following markdown will _not_ cause a warning:
+
+```md
+- [Example team](https://example.com/team)
+```
+
 💡 For all banned phrases that begin with `this` or `the`, any words that come between will also fail. For example "this post", "this W3C post", and "this W3C blog post" will all fail.
 
 ### Link text is not unique
@@ -45,12 +57,14 @@ Here’s a sample of the phrases in [`src/banned.ts`](src/banned.ts):
 This warning relates to [WCAG 2.4.9 Link Purpose (Link Only) (AAA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=249#link-purpose-link-only) and [WCAG 3.2.4 Consistent Navigation (AA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=324#consistent-identification). Links with different purposes and destinations should have different link text. Descriptive link text communicates a link's purpose even when the context is missing. A screen reader listing all of the links on a page is an example where the context would be missing.
 
 🚫 The following markdown will cause a warning:
+
 ```md
 - [Example](https://example.com/team)
 - [Example](https://example.com/about)
 ```
 
-✅ The following markdown will *not* cause a warning:
+✅ The following markdown will _not_ cause a warning:
+
 ```md
 - [Example team](https://example.com/team)
 - [About Example](https://example.com/about)
@@ -63,13 +77,15 @@ This warning relates to [WCAG 2.4.9 Link Purpose (Link Only) (AAA)](https://www.
 [WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context) considers a link containing text that gives a description of the information at that URL a sufficient technique. When a URL is the link text, screen readers have to listen while the reader pronounces every single character of a URL. Audibly, this is less descriptive and more time consuming to listen to than descriptive link text. [WebAIM's Links and Hypertext page](https://webaim.org/techniques/hypertext/link_text) explains the challenges of [URLs as links](https://webaim.org/techniques/hypertext/link_text#urls).
 
 🚫 The following markdown will cause a warning:
+
 ```md
 [https://www.w3c.org/WAI/fundamentals/accessibility-intro/](https://www.w3c.org/WAI/fundamentals/accessibility-intro/)
 ```
 
 When read aloud, users will hear "h t t p s colon slash slash w w w dot w 3 c dot org slash w a i slash fundementals slash accessibility dash intro slash, link".
 
-✅ The following markdown will *not* cause a warning:
+✅ The following markdown will _not_ cause a warning:
+
 ```md
 [Introduction to Web Accessibility](https://www.w3c.org/WAI/fundamentals/accessibility-intro/)
 ```
@@ -83,11 +99,13 @@ When read aloud, users will hear "Introduction to Web Accessibility, link".
 In markdown, missing link text is often an oversight. Although an [`<a>` element without a `href` attribute is valid](https://html.spec.whatwg.org/#the-a-element) HTML, [WebAIM suggests that empty links can be very confusing](https://webaim.org/techniques/hypertext/link_text#empty_links) to keyboard and screen reader users and should be avoided completely.
 
 🚫 The following markdown will cause a warning:
+
 ```md
 [](https://example.com)
 ```
 
-✅ The following markdown will *not* cause a warning:
+✅ The following markdown will _not_ cause a warning:
+
 ```md
 [Example](https://example.com)
 ```
@@ -97,11 +115,13 @@ In markdown, missing link text is often an oversight. Although an [`<a>` element
 When an image is the only content in a link, alt text is required. In this context, missing alt text is a [failure of WCAG 2.4.4 (A), 2.4.9 (AAA), and 4.1.2 (A)](https://www.w3.org/WAI/WCAG21/Techniques/failures/F89).
 
 🚫 The following markdown will cause a warning:
+
 ```md
 [![](https://example.com/logo.svg)](https://example.com)
 ```
 
-✅ The following markdown will *not* cause a warning:
+✅ The following markdown will _not_ cause a warning:
+
 ```md
 [![Example logo](https://example.com/logo.svg)](https://example.com)
 ```

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,7 +21,7 @@ describe("remark-lint-link-text", () => {
       dedent`
       # Title
 
-      A good link: Visit [Mapbox Documentation](https://docs.mapbox.com) for more infomration.
+      A good link: Visit [Mapbox Documentation](https://docs.mapbox.com) for more information.
 
       A bad link: [click here](https://docs.mapbox.com).
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,19 +21,19 @@ describe("remark-lint-link-text", () => {
       dedent`
       # Title
 
-      A good link: Visit [Mapbox Documentation](https://docs.mapbox.com) for more information.
+      A good link: Visit [Example’s website](https://example.com) for more information.
 
-      A bad link: [click here](https://docs.mapbox.com).
+      A bad link: [click here](https://example.com).
 
-      A bad link: [link](https://google.com)
+      A bad link: [link](https://example.com)
     `
     );
 
     expect(lint.messages.length).toEqual(2);
     expect(lint.messages).toMatchInlineSnapshot(`
       Array [
-        [5:13-5:50: Avoid using the link text “click here,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination.],
-        [7:13-7:39: Avoid using the link text “link,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination.],
+        [5:13-5:46: Avoid using the link text “click here,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination.],
+        [7:13-7:40: Avoid using the link text “link,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination.],
       ]
     `);
   });
@@ -43,7 +43,7 @@ describe("remark-lint-link-text", () => {
       dedent`
       # Title
 
-      A bad link: [Click here](https://docs.mapbox.com).
+      A bad link: [Click here](https://example.com).
     `
     );
 
@@ -55,12 +55,12 @@ describe("remark-lint-link-text", () => {
 
   test("warns against url as link text", async () => {
     const lint = await processMarkdown(
-      dedent`A bad link: [https://github.com.com](https://github.com.com).`
+      dedent`A bad link: [https://example.com/initiatives/business/papers/important-ones.htm](https://example.com/initiatives/business/papers/important-ones.htm).`
     );
 
     expect(lint.messages.length).toEqual(1);
     expect(lint.messages[0].reason).toMatchInlineSnapshot(
-      `"Avoid using a URL “https://github.com.com” as the link text. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination."`
+      `"Avoid using a URL “https://example.com/initiatives/business/papers/important-ones.htm” as the link text. Consider users who must speak it out loud and who must listen to a screen reader announce it. Replace it with a short description of the link’s destination."`
     );
   });
 
@@ -69,7 +69,7 @@ describe("remark-lint-link-text", () => {
       dedent`
       # Title
 
-      A good link: [the Mapbox Isochrone API documentation](https://docs.mapbox.com).
+      A good link: [important business papers](https://example.com/initiatives/business/papers/important-ones.htm).
     `
     );
 
@@ -79,9 +79,9 @@ describe("remark-lint-link-text", () => {
   test("should pass", async () => {
     const lint = await processMarkdown(
       dedent`
-      ## Option 1: Choropleth
+      ## Example 1
       
-      In this option, we will create a choropleth visualization using data from [The Washington Post's "2ºC: Beyond the Limit" series about rising temperatures](https://github.com/washingtonpost/data-2C-beyond-the-limit-usa), which analyzes warming temperatures in the United States.
+      In this example we link to [important business papers](https://example.com/initiatives/business/papers/important-ones.htm) for more information.
     `
     );
     expect(lint.messages.length).toEqual(0);
@@ -89,47 +89,47 @@ describe("remark-lint-link-text", () => {
 
   test("unique link text", async () => {
     const lint = await processMarkdown(
-      dedent`Visit the [staff directory](https://www.directory.org) to learn more. You can visit the other [staff directory](https://www.other-directory.org) to learn other stuff.`
+      dedent`Visit the [staff directory](https://example.com/about-us/) to learn more. You can visit the other [staff directory](https://example.com/team/directory/) to learn other stuff.`
     );
     expect(lint.messages).toMatchInlineSnapshot(`
       Array [
-        [1:11-1:55: The link text “staff directory” is used more than once with different URLs. Change the link text to be unique to the URL.],
+        [1:11-1:59: The link text “staff directory” is used more than once with different URLs. Change the link text to be unique to the URL.],
       ]
     `);
   });
 
   test("link with image", async () => {
     const lint = await processMarkdown(
-      dedent`Visit the [staff directory ![](https://my-image.png)](https://www.directory.org).`
+      dedent`Visit the [staff directory ![](example.png)](https://example.com).`
     );
     expect(lint.messages).toMatchInlineSnapshot(`Array []`);
   });
 
   test("link is image, no alt text", async () => {
     const lint = await processMarkdown(
-      dedent`Visit the [![](https://my-image.png)](https://www.directory.org).`
+      dedent`Visit the [![](example.png)](https://example.com).`
     );
     expect(lint.messages).toMatchInlineSnapshot(`
       Array [
-        [1:11-1:65: The link “https://www.directory.org” must have link text or the image inside the link must have alt text],
+        [1:11-1:50: The link “https://example.com” must have link text or the image inside the link must have alt text],
       ]
     `);
   });
 
   test("link is image, alt text", async () => {
     const lint = await processMarkdown(
-      dedent`Visit the [![staff directory](https://my-image.png)](https://www.directory.org).`
+      dedent`Visit the [![staff directory](example.png)](https://example.com).`
     );
     expect(lint.messages).toMatchInlineSnapshot(`Array []`);
   });
 
   test("missing link text", async () => {
     const lint = await processMarkdown(
-      dedent`Visit the [](https://www.directory.org).`
+      dedent`Visit the [](https://example.com).`
     );
     expect(lint.messages).toMatchInlineSnapshot(`
       Array [
-        [1:11-1:40: The link “https://www.directory.org” must have link text],
+        [1:11-1:34: The link “https://example.com” must have link text],
       ]
     `);
   });
@@ -139,29 +139,29 @@ describe("remark-lint-link-text", () => {
       dedent`
       # Title
 
-      A bad link: [this mapbox article](https://docs.mapbox.com).
-      A bad link: [this Mapbox article](https://docs.mapbox.com).
-      A bad link: [this article](https://docs.mapbox.com).
-      A bad link: [this blog post](https://docs.mapbox.com).
-      A bad link: [the Mapbox blog post](https://docs.mapbox.com).
+      A bad link: [this example article](https://example.com).
+      A bad link: [this article](https://example.com).
+      A bad link: [click here](https://example.com).
+      A bad link: [this blog post](https://example.com).
+      A bad link: [the example blog post](https://example.com).
     `
     );
 
     expect(lint.messages.length).toEqual(5);
     expect(lint.messages[0].reason).toMatchInlineSnapshot(
-      `"Avoid using the link text “this mapbox article,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
+      `"Avoid using the link text “this example article,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
     );
     expect(lint.messages[1].reason).toMatchInlineSnapshot(
-      `"Avoid using the link text “this Mapbox article,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
+      `"Avoid using the link text “this article,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
     );
     expect(lint.messages[2].reason).toMatchInlineSnapshot(
-      `"Avoid using the link text “this article,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
+      `"Avoid using the link text “click here,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
     );
     expect(lint.messages[3].reason).toMatchInlineSnapshot(
       `"Avoid using the link text “this blog post,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
     );
     expect(lint.messages[4].reason).toMatchInlineSnapshot(
-      `"Avoid using the link text “the Mapbox blog post,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
+      `"Avoid using the link text “the example blog post,” it can be confusing when a screen reader reads it out of context. Replace it with a short description of the link’s destination."`
     );
   });
 });


### PR DESCRIPTION
This PR fixes #7 with an overhaul to the readme. I tried to link these to relevant WCAG guidelines and show clear examples.

This also rewords the feedback in `src/__tests__/index.test.ts` to match the style of the readme.

Very open to tweaks!