### PR TITLE
Email address test

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ When an image is the only content in a link, alt text is required. In this conte
 
 💡 When an image is the only content in a link, the image's alt text effectively becomes the link text. Based on [WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context), the alt text should describle the function of the link (instead of describing the image).
 
+### Link to email does not contain email address in link text
+
+When linking to an email address, using `mailto:`, the email address should be in the link text. This provides users with context for what will happen when interacting with the link (a new email message will open in email application). Also, email in the link text is useful context when the link can't be activated (plain text paste, printed page).
+
+```md
+[Email me](mailto:email@example.com)
+```
+
+✅ The following markdown will _not_ cause a warning:
+
+```md
+[email@example.com](mailto:email@example.com)
+```
+
 ## More link text resources
 
 - [A11y Collective: The Perfect Link](https://www.a11y-collective.com/blog/the-perfect-link/)

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ When linking to an email address, using `mailto:`, the email address should be i
 [email@example.com](mailto:email@example.com)
 ```
 
+```md
+[otheremail@example.com](mailto:otheremail@example.com?subject=hello)
+```
+
 ## More link text resources
 
 - [A11y Collective: The Perfect Link](https://www.a11y-collective.com/blog/the-perfect-link/)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ When an image is the only content in a link, alt text is required. In this conte
 
 When linking to an email address, using `mailto:`, the email address should be in the link text. This provides users with context for what will happen when interacting with the link (a new email message will open in email application). Also, email in the link text is useful context when the link can’t be activated (plain text paste, printed page).
 
+🚫 The following markdown will cause a warning:
+
 ```md
 [Email me](mailto:email@example.com)
 ```

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Here’s a sample of the phrases in [`src/banned.ts`](src/banned.ts):
 - [Example team](https://example.com/team)
 ```
 
-💡 For all banned phrases that begin with `this` or `the`, any words that come between will also fail. For example "this post", "this W3C post", and "this W3C blog post" will all fail.
+💡 For all banned phrases that begin with `this` or `the`, any words that come between will also fail. For example “this post”, “this W3C post”, and “this W3C blog post” will all fail.
 
 ### Link text is not unique
 
-This warning relates to [WCAG 2.4.9 Link Purpose (Link Only) (AAA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=249#link-purpose-link-only) and [WCAG 3.2.4 Consistent Navigation (AA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=324#consistent-identification). Links with different purposes and destinations should have different link text. Descriptive link text communicates a link's purpose even when the context is missing. A screen reader listing all of the links on a page is an example where the context would be missing.
+This warning relates to [WCAG 2.4.9 Link Purpose (Link Only) (AAA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=249#link-purpose-link-only) and [WCAG 3.2.4 Consistent Navigation (AA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=324#consistent-identification). Links with different purposes and destinations should have different link text. Descriptive link text communicates a link’s purpose even when the context is missing. A screen reader listing all of the links on a page is an example where the context would be missing.
 
 🚫 The following markdown will cause a warning:
 
@@ -74,7 +74,7 @@ This warning relates to [WCAG 2.4.9 Link Purpose (Link Only) (AAA)](https://www.
 
 ### Link text is a URL
 
-[WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context) considers a link containing text that gives a description of the information at that URL a sufficient technique. When a URL is the link text, screen readers have to listen while the reader pronounces every single character of a URL. Audibly, this is less descriptive and more time consuming to listen to than descriptive link text. [WebAIM's Links and Hypertext page](https://webaim.org/techniques/hypertext/link_text) explains the challenges of [URLs as links](https://webaim.org/techniques/hypertext/link_text#urls).
+[WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context) considers a link containing text that gives a description of the information at that URL a sufficient technique. When a URL is the link text, screen readers have to listen while the reader pronounces every single character of a URL. Audibly, this is less descriptive and more time consuming to listen to than descriptive link text. [WebAIM’s Links and Hypertext page](https://webaim.org/techniques/hypertext/link_text) explains the challenges of [URLs as links](https://webaim.org/techniques/hypertext/link_text#urls).
 
 🚫 The following markdown will cause a warning:
 
@@ -82,7 +82,7 @@ This warning relates to [WCAG 2.4.9 Link Purpose (Link Only) (AAA)](https://www.
 [https://www.w3c.org/WAI/fundamentals/accessibility-intro/](https://www.w3c.org/WAI/fundamentals/accessibility-intro/)
 ```
 
-When read aloud, users will hear "h t t p s colon slash slash w w w dot w 3 c dot org slash w a i slash fundementals slash accessibility dash intro slash, link".
+When read aloud, users will hear “h t t p s colon slash slash w w w dot w 3 c dot org slash w a i slash fundementals slash accessibility dash intro slash, link”.
 
 ✅ The following markdown will _not_ cause a warning:
 
@@ -90,7 +90,7 @@ When read aloud, users will hear "h t t p s colon slash slash w w w dot w 3 c do
 [Introduction to Web Accessibility](https://www.w3c.org/WAI/fundamentals/accessibility-intro/)
 ```
 
-When read aloud, users will hear "Introduction to Web Accessibility, link".
+When read aloud, users will hear “Introduction to Web Accessibility, link”.
 
 💡 This check is at odds with some stylistic guidelines, like APA. The [APA Style’s Accessible URLs page](https://apastyle.apa.org/style-grammar-guidelines/paper-format/accessibility/urls) provides some rationale for their guidelines as it relates to [WCAG 2.4.4](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context).
 
@@ -126,11 +126,11 @@ When an image is the only content in a link, alt text is required. In this conte
 [![Example logo](https://example.com/logo.svg)](https://example.com)
 ```
 
-💡 When an image is the only content in a link, the image's alt text effectively becomes the link text. Based on [WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context), the alt text should describle the function of the link (instead of describing the image).
+💡 When an image is the only content in a link, the image’s alt text effectively becomes the link text. Based on [WCAG 2.4.4 Link Purpose (In Context) (A)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-in-context), the alt text should describle the function of the link (instead of describing the image).
 
 ### Link to email does not contain email address in link text
 
-When linking to an email address, using `mailto:`, the email address should be in the link text. This provides users with context for what will happen when interacting with the link (a new email message will open in email application). Also, email in the link text is useful context when the link can't be activated (plain text paste, printed page).
+When linking to an email address, using `mailto:`, the email address should be in the link text. This provides users with context for what will happen when interacting with the link (a new email message will open in email application). Also, email in the link text is useful context when the link can’t be activated (plain text paste, printed page).
 
 ```md
 [Email me](mailto:email@example.com)
@@ -145,7 +145,7 @@ When linking to an email address, using `mailto:`, the email address should be i
 ## More link text resources
 
 - [A11y Collective: The Perfect Link](https://www.a11y-collective.com/blog/the-perfect-link/)
-- [Get Stark: The endless search for "here" in the unhelpful "click here" button](https://www.getstark.co/blog/the-endless-search-for-here-in-the-unhelpful-click-here-button)
+- [Get Stark: The endless search for “here” in the unhelpful “click here” button](https://www.getstark.co/blog/the-endless-search-for-here-in-the-unhelpful-click-here-button)
 - [NC State University: Accessible Hyperlinks](https://accessibility.oit.ncsu.edu/accessible-hyperlinks/)
 - [Penn State: Link Text](https://accessibility.psu.edu/linktext/)
 - [WCAG 2.4.4: Link Purpose](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -134,6 +134,16 @@ describe("remark-lint-link-text", () => {
     `);
   });
 
+  test.only("email address", async () => {
+    const lint = await processMarkdown(
+      dedent`
+Bad: [Email me](mailto:myemail@mail.com)
+Good: [myemail@mail.com](mailto:myemail@mail.com)
+`
+    );
+    expect(lint.messages).toMatchInlineSnapshot(`Array []`);
+  });
+
   test("warns against banned link text, regex match", async () => {
     const lint = await processMarkdown(
       dedent`

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -137,9 +137,9 @@ describe("remark-lint-link-text", () => {
   test.only("email address", async () => {
     const lint = await processMarkdown(
       dedent`
-Bad: [Email me](mailto:myemail@mail.com)
-Good: [myemail@mail.com](mailto:myemail@mail.com)
-`
+      Bad: [Email me](mailto:email@example.com)
+      Good: [email@example.com](mailto:email@example.com)
+    `
     );
     expect(lint.messages).toMatchInlineSnapshot(`Array []`);
   });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -134,14 +134,19 @@ describe("remark-lint-link-text", () => {
     `);
   });
 
-  test.only("email address", async () => {
+  test("email address", async () => {
     const lint = await processMarkdown(
       dedent`
       Bad: [Email me](mailto:email@example.com)
+      Good: [otheremail@example.com](mailto:otheremail@example.com?subject=hey)
       Good: [email@example.com](mailto:email@example.com)
     `
     );
-    expect(lint.messages).toMatchInlineSnapshot(`Array []`);
+    expect(lint.messages).toMatchInlineSnapshot(`
+      Array [
+        [1:6-1:42: Text must include email “email@example.com” because the link URL will generate an email message],
+      ]
+    `);
   });
 
   test("warns against banned link text, regex match", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import checkRegexBannedWords from "./rules/regex-banned-words.js";
 import checkBannedWords from "./rules/banned-words.js";
 import checkIsNotUrl from "./rules/not-url.js";
 import checkUniqueLinkText from "./rules/unique.js";
+import checkEmail from "./rules/email.js";
 
 const checkLinkText = lintRule(
   "remark-lint:link-text",
@@ -35,6 +36,7 @@ const checkLinkText = lintRule(
       message(checkRegexBannedWords({ text }));
       message(checkBannedWords({ text }));
       message(checkIsNotUrl({ text }));
+      message(checkEmail({ node, text }));
 
       if (!textToNodes[text]) {
         textToNodes[text] = [];

--- a/src/rules/email.ts
+++ b/src/rules/email.ts
@@ -1,0 +1,18 @@
+import { TextNode } from "../index.js";
+
+export default function checkEmail({
+  node,
+  text,
+}: {
+  node: TextNode;
+  text: string;
+}) {
+  const { url } = node;
+  if (!url || !url.startsWith("mailto:")) return;
+  // check the `text` to see if it has the email.
+  // create var with just the email.
+  const email = url.replace("mailto:", "");
+  if (text.includes(email)) {
+    return "Text must include email";
+  }
+}

--- a/src/rules/email.ts
+++ b/src/rules/email.ts
@@ -9,10 +9,9 @@ export default function checkEmail({
 }) {
   const { url } = node;
   if (!url || !url.startsWith("mailto:")) return;
-  // check the `text` to see if it has the email.
-  // create var with just the email.
-  const email = url.replace("mailto:", "");
-  if (text.includes(email)) {
-    return "Text must include email";
+  const emailArray = url.split("?");
+  const email = emailArray[0].replace("mailto:", "");
+  if (!text.includes(email)) {
+    return `Text must include email “${email}” because the link URL will generate an email message`;
   }
 }


### PR DESCRIPTION
This PR adds a test that will check links that include `mailto:` and confirm that the link text includes the email address. The rationale for this test is included in the readme.

This also replaces all single and double quotes in the readme with smart quotes.